### PR TITLE
bit-register can specify endianness of underlying type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14,6 +23,7 @@ version = "0.1.0"
 dependencies = [
  "num-traits",
  "proptest",
+ "rstest",
 ]
 
 [[package]]
@@ -53,6 +63,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +89,49 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -98,6 +157,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +197,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,12 +218,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -229,10 +337,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -260,6 +436,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +472,23 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -391,6 +599,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Dylan Knutson <dylanknutson@microsoft.com>"]
 description = "Utilities and crates for embedded Rust development"

--- a/crates/bit-register/Cargo.toml
+++ b/crates/bit-register/Cargo.toml
@@ -11,6 +11,7 @@ num-traits.workspace = true
 
 [dev-dependencies]
 proptest = "1.4.0"
+rstest = "0.25.0"
 
 [lints]
 workspace = true

--- a/crates/bit-register/README.md
+++ b/crates/bit-register/README.md
@@ -14,6 +14,7 @@ This crate provides a macro for defining register types with bit field support, 
 - Range validation for field values to prevent overflow
 - Support for various integer sizes (u8, u16, u32, u64)
 - Support for different field types (boolean, numeric, enum)
+- Support for specifying `big_endian` or `little_endian` byte order (defaults to `little_endian`)
 - Fully compatible with no_std environments
 
 ## Usage
@@ -51,6 +52,83 @@ let bits: u16 = status.try_into().unwrap();
 
 // Create from bits
 let status_from_bits = StatusRegister::try_from(bits).unwrap();
+```
+
+### Defining a Register with Specific Byte Order
+
+By default, registers are assumed to be little-endian. You can specify `big_endian` if needed.
+
+```rust
+use bit_register::bit_register;
+
+bit_register! {
+    #[derive(Debug, PartialEq)]
+    pub struct BigEndianRegister: big_endian u32 { // Specify big_endian here
+        pub field_a: u8 => [0:7],
+        pub field_b: u16 => [8:23],
+        pub field_c: u8 => [24:31]
+    }
+}
+
+// Example: We want to represent the conceptual big-endian u32 represented by the bytes [0x78, 0x56, 0x34, 0x12].
+// In this conceptual big-endian number:
+// - `field_a` (bits 0-7) corresponds to the least significant byte: 0x78.
+// - `field_b` (bits 8-23) corresponds to the middle bytes: 0x3456.
+// - `field_c` (bits 24-31) corresponds to the most significant byte: 0x12.
+let register = BigEndianRegister {
+    field_a: 0x78,
+    field_b: 0x3456,
+    field_c: 0x12,
+};
+
+// When converting to a u32 (e.g., for storage or network transmission):
+// On a little-endian platform, the big-endian value 0x12345678 is represented as 0x78563412.
+let bits: u32 = register.try_into().unwrap();
+assert_eq!(bits, u32::from_be_bytes([0x78, 0x56, 0x34, 0x12]));
+
+// To create a register from a u32 value:
+// The input `raw_value_from_platform` is a u32 in the platform's native endianness.
+// Assume this value was obtained by reading a big-endian data source.
+// For instance, if a hardware register or network packet contains the byte sequence [0x12, 0x34, 0x56, 0x78]
+// (which is 0x12345678 in big-endian), reading this as a u32 on a little-endian platform
+// will result in `raw_value_from_platform` being 0x78563412.
+let raw_value_from_platform = u32::from_be_bytes([0x78, 0x56, 0x34, 0x12]);
+let register_from_bits = BigEndianRegister::try_from(raw_value_from_platform).unwrap();
+
+// Inside `try_from` for a `big_endian` register, `raw_value_from_platform` (0x[78, 56, 34, 12])
+// is byte-swapped to its conceptual big-endian form (0x[12, 34, 56, 78]).
+// Fields are then extracted from this conceptual form (0x[12, 34, 56, 78]):
+// - field_a (bits 0-7) will be 0x78.
+// - field_b (bits 8-23) will be 0x3456.
+// - field_c (bits 24-31) will be 0x12.
+assert_eq!(register_from_bits.field_a, 0x78);
+assert_eq!(register_from_bits.field_b, 0x3456);
+assert_eq!(register_from_bits.field_c, 0x12);
+
+bit_register! {
+    #[derive(Debug, PartialEq)]
+    pub struct LittleEndianRegister: little_endian u16 { // Explicitly little_endian
+        pub low_byte: u8 => [0:7],
+        pub high_byte: u8 => [8:15]
+    }
+}
+
+// Contrast this with a little-endian register
+let le_register_value = u16::from_le_bytes([0x34, 0x12]);
+
+let le_bits: u16 = LittleEndianRegister {
+    low_byte: 0x34,
+    high_byte: 0x12,
+}
+.try_into()
+.unwrap();
+
+assert_eq!(le_bits, le_register_value);
+
+let le_reg_from_bits = LittleEndianRegister::try_from(le_register_value).unwrap();
+assert_eq!(le_reg_from_bits.low_byte, 0x34);
+assert_eq!(le_reg_from_bits.high_byte, 0x12);
+
 ```
 
 ### Defining an Enum with Bit Representation
@@ -115,4 +193,4 @@ This crate is particularly useful for:
 
 ## License
 
-This crate is licensed under the same license as the parent repository. 
+MIT license

--- a/crates/bit-register/src/lib.rs
+++ b/crates/bit-register/src/lib.rs
@@ -154,10 +154,33 @@ macro_rules! bit_register {
         }
     };
 
+     // Entrypoint with no endianness annotation, default to little endian
+     (
+        $(#[$attr:meta])*
+        $vis:vis struct $name:ident: $underlying_type:ty {
+            $(
+                $(#[$field_attr:meta])*
+                $field_vis:vis $field_name:ident: $field_type:tt => $field_bits:tt
+            ),* $(,)?
+        }
+    ) => {
+        bit_register! {
+            $(#[$attr])*
+            #[deprecated(note = "Please explicitly specify `little_endian` byte order for bit_register! struct")]
+            $vis struct $name: little_endian $underlying_type {
+                $(
+                    $(#[$field_attr])*
+                    $field_vis $field_name: $field_type => $field_bits
+                ),*
+            }
+        }
+    };
+
+    // Entrypoint with endianness annotation
     // Define a struct type which can be used as a bit register
     (
         $(#[$attr:meta])*
-        $vis:vis struct $name:ident: $underlying_type:ty {
+        $vis:vis struct $name:ident: $endianness:ident $underlying_type:ty {
             $(
                 $(#[$field_attr:meta])*
                 $field_vis:vis $field_name:ident: $field_type:tt => $field_bits:tt
@@ -180,6 +203,8 @@ macro_rules! bit_register {
             type Error = &'static str;
 
             fn try_from(value: $underlying_type) -> Result<Self, Self::Error> {
+
+                let value = bit_register!(@fix_endiannesss $endianness, value);
                 $(
                     let $field_name = bit_register!(@extract_bits $underlying_type, value, $field_type, $field_bits);
                 )*
@@ -201,12 +226,22 @@ macro_rules! bit_register {
                     // Handle bit packing for each field
                     value |= bit_register!(@pack_bits $underlying_type, self.$field_name, $field_name, $field_type, $field_bits);
                 )*
+                let value = bit_register!(@fix_endiannesss $endianness, value);
                 Ok(value)
             }
         }
 
         impl $crate::BitRegister<$underlying_type> for $name {}
     };
+
+    // swap bytes of `value` if big endian (assumes little endian platforms)
+    (@fix_endiannesss big_endian, $value:expr) => {
+        $value.swap_bytes()
+    };
+
+    // no-op if little endian
+    (@fix_endiannesss little_endian, $value:expr) => { $value };
+
 
     // Extract a single bit, convert to range
     (@extract_bits $underlying_type:ty, $value:expr, $field_type:ty, [$bit:literal]) => {
@@ -240,7 +275,6 @@ macro_rules! bit_register {
             $crate::TryFromBits::try_from_bits(extracted_value)?
         }
     };
-
 
     // Pack a single bit field
     (@pack_bits $underlying_type:ty, $field_value:expr, $field_name:ident, $field_type:tt, [$bit:literal]) => {
@@ -286,9 +320,9 @@ macro_rules! bit_register {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod test {
     use super::*;
-
     #[test]
     fn test_basic_register() {
         bit_register! {
@@ -685,6 +719,7 @@ mod test {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod property_tests {
     extern crate std;
 
@@ -920,6 +955,115 @@ mod property_tests {
         let _result = RestrictedEnumRegister::try_from(too_large);
         // This might or might not error depending on how the macro works
         // (it may just mask the value to fit in 3 bits)
+    }
+
+    bit_register! {
+        #[derive(Debug, Clone, Copy, PartialEq)]
+        pub struct RxFifoHeader: big_endian u32 {
+            pub cycle_type: u8 => [24:31],
+            pub tag: u8 => [20:23],
+            pub length: u16 => [8:19],
+            pub byte0: u8 => [0:7],
+        }
+    }
+
+    #[rstest::rstest]
+    #[case(0x01_08_00_21, RxFifoHeader{
+        cycle_type: 0x21,
+        tag: 0x00,
+        length: 0x08,
+        byte0: 0x01,
+    })]
+    #[case(0x00_00_00_00, RxFifoHeader{
+        cycle_type: 0x00,
+        tag: 0x00,
+        length: 0x00,
+        byte0: 0x00,
+    })]
+    #[case(0x15_64_A2_03, RxFifoHeader{
+        cycle_type: 0x03,
+        tag: 0x0A,
+        length: 0x264,
+        byte0: 0x15,
+    })]
+    fn test_big_endian(#[case] input: u32, #[case] expected: RxFifoHeader) {
+        let register = RxFifoHeader::try_from(input).unwrap();
+        assert_eq!(register, expected, "0x{:X} => {:X?}", input, register);
+
+        let roundtrip: u32 = register.try_into().unwrap();
+        assert_eq!(roundtrip, input, "{:X?} => 0x{:X}", register, roundtrip);
+    }
+
+    // This is the example from the README.md
+    #[test]
+    fn test_readme_be_example() {
+        bit_register! {
+            #[derive(Debug, PartialEq)]
+            pub struct BigEndianRegister: big_endian u32 { // Specify big_endian here
+                pub field_a: u8 => [0:7],
+                pub field_b: u16 => [8:23],
+                pub field_c: u8 => [24:31]
+            }
+        }
+
+        // Example: We want to represent the conceptual big-endian u32 represented by the bytes [0x78, 0x56, 0x34, 0x12].
+        // In this conceptual big-endian number:
+        // - `field_c` (bits 24-31) corresponds to the most significant byte: 0x12.
+        // - `field_b` (bits 8-23) corresponds to the middle bytes: 0x3456.
+        // - `field_a` (bits 0-7) corresponds to the least significant byte: 0x78.
+        let register = BigEndianRegister {
+            field_a: 0x78,
+            field_b: 0x3456, // This is 0x3456 for the conceptual BE value 0x12345678
+            field_c: 0x12,
+        };
+
+        // When converting to a u32 (e.g., for storage or network transmission):
+        // On a little-endian platform, the big-endian value 0x12345678 is represented as 0x78563412.
+        let bits: u32 = register.try_into().unwrap();
+        assert_eq!(bits, u32::from_be_bytes([0x78, 0x56, 0x34, 0x12]));
+
+        // To create a register from a u32 value:
+        // The input `raw_value_from_platform` is a u32 in the platform's native endianness.
+        // Assume this value was obtained by reading a big-endian data source.
+        // For instance, if a hardware register or network packet contains the byte sequence [0x12, 0x34, 0x56, 0x78]
+        // (which is 0x12345678 in big-endian), reading this as a u32 on a little-endian platform
+        // will result in `raw_value_from_platform` being 0x78563412.
+        let raw_value_from_platform = u32::from_be_bytes([0x78, 0x56, 0x34, 0x12]);
+        let register_from_bits = BigEndianRegister::try_from(raw_value_from_platform).unwrap();
+
+        // Inside `try_from` for a `big_endian` register, `raw_value_from_platform` (0x[78, 56, 34, 12])
+        // is byte-swapped to its conceptual big-endian form (0x[12, 34, 56, 78]).
+        // Fields are then extracted from this conceptual form (0x[12, 34, 56, 78]):
+        // - field_a (bits 0-7) will be 0x78.
+        // - field_b (bits 8-23) will be 0x3456.
+        // - field_c (bits 24-31) will be 0x12.
+        assert_eq!(register_from_bits.field_a, 0x78);
+        assert_eq!(register_from_bits.field_b, 0x3456);
+        assert_eq!(register_from_bits.field_c, 0x12);
+
+        bit_register! {
+            #[derive(Debug, PartialEq)]
+            pub struct LittleEndianRegister: little_endian u16 { // Explicitly little_endian
+                pub low_byte: u8 => [0:7],
+                pub high_byte: u8 => [8:15]
+            }
+        }
+
+        // Contrast this with a little-endian register
+        let le_register_value = u16::from_le_bytes([0x34, 0x12]);
+
+        let le_bits: u16 = LittleEndianRegister {
+            low_byte: 0x34,
+            high_byte: 0x12,
+        }
+        .try_into()
+        .unwrap();
+
+        assert_eq!(le_bits, le_register_value);
+
+        let le_reg_from_bits = LittleEndianRegister::try_from(le_register_value).unwrap();
+        assert_eq!(le_reg_from_bits.low_byte, 0x34);
+        assert_eq!(le_reg_from_bits.high_byte, 0x12);
     }
 
     // Tests for mixed fields


### PR DESCRIPTION
See changes to README.md for more details; allows a `bit_register!` defined struct to be backed by a big endian value. By default, it was little endian, which worked for most situation, but when working with data in e.g. network byte order (BE), this was too restrictive. 