### PR TITLE
code-size: Create simple stack size inspection tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,10 +104,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "camino"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-stack-size"
+version = "0.1.0"
+dependencies = [
+ "cargo_metadata",
+ "clap",
+ "rustc-demangle",
+ "stack-sizes",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dc1a6f7b5651af85774ae5a34b4e8be397d9cf4bc063b7e6dbd99a841837830"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror",
+ "toml",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cfca2aaa699835ba88faf58a06342a314a950d2b9686165e038286c30316868"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "cargo-util-schemas",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "debug-non-default"
@@ -63,10 +230,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -89,6 +277,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -169,6 +366,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,10 +489,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -195,6 +523,12 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "memchr"
@@ -218,6 +552,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +583,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -402,6 +766,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,10 +806,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "slab"
@@ -451,6 +892,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stack-sizes"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feea0c7c3779faa3e1420b29d8041fdb0afe9c4f4ee2d6cc6a903054b8897f05"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "leb128",
+ "xmas-elf",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +930,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -475,21 +957,81 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.9"
+name = "thiserror"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "unarray"
@@ -502,6 +1044,35 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wait-timeout"
@@ -619,6 +1190,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xmas-elf"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22678df5df766e8d1e5d609da69f0c3132d794edf6ab5e75e7abcd2270d4cf58"
+dependencies = [
+ "zero",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zero"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"
+
+[[package]]
 name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +1248,60 @@ name = "zerocopy-derive"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ bit-register = { path = "crates/bit-register" }
 debug-non-default = { path = "crates/debug-non-default" }
 
 [workspace.lints.clippy]
-suspicious = "forbid"
-correctness = "forbid"
-perf = "forbid"
-style = "forbid"
+suspicious = "deny"
+correctness = "deny"
+perf = "deny"
+style = "deny"
 
 [workspace.lints.rust]
 missing_docs = "warn"
-unsafe_code = "forbid"
-unexpected_cfgs = "forbid"
-unused_qualifications = "forbid"
+unsafe_code = "deny"
+unexpected_cfgs = "deny"
+unused_qualifications = "deny"

--- a/crates/cargo-stack-size/Cargo.toml
+++ b/crates/cargo-stack-size/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cargo-stack-size"
+version = "0.1.0"
+edition = "2024"
+description = "A tool for inspecting binary stack size by function and crate"
+repository = "https://github.com/OpenDevicePartnership/odp-utilities"
+license = "MIT"
+authors = ["Kurtis Dinelle <kdinelle@microsoft.com>"]
+
+[dependencies]
+cargo_metadata = "0.21.0"
+clap = { version = "4.5.41", features = ["derive"] }
+rustc-demangle = "0.1.25"
+stack-sizes = "0.5.0"
+
+[lints]
+workspace = true
+

--- a/crates/cargo-stack-size/README.md
+++ b/crates/cargo-stack-size/README.md
@@ -1,0 +1,76 @@
+# cargo-stack-size
+A tool for inspecting binary stack size by function and crate.
+
+## Install
+`cargo install --git https://github.com/OpenDevicePartnership/odp-utilities cargo-stack-size`
+
+## Heads Up
+This tool makes use of the unstable flag [`-Zemit-stack-sizes`](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/emit-stack-sizes.html) which requires the `nightly` toolchain.
+
+This flag may or may not work correctly depending on target, and is not guaranteed to work on all versions of `nightly`.
+However it appears to work correctly on Linux and ARM Cortex-M ELF binaries.
+
+Therefore, to use this tool, you must ensure the `-Zemit-stack-sizes` flag is set,
+either in the `RUSTFLAGS` env variable or within `.cargo/config.toml`. You can also instruct this
+tool to include the flag for you (see [Usage](#usage)) but be warned that would override any other flags set.
+
+Lastly, as `nightly` is required, reported stack sizes may differ slightly from a `stable` build.
+
+## Usage
+Show full list of arguments and usage:  
+`cargo stack-size --help`
+
+Show top 10 functions by stack size in release build:  
+`cargo stack-size -n 10 --release`
+
+Show all functions by stack size and include `-Zemit-stack-sizes`:  
+`cargo stack-size -n 0 --emit-stack-sizes`
+
+Show top functions by stack size for given crate:  
+`cargo stack-size --crate cargo_stack_size`
+
+Show top functions by stack size matching given name:  
+`cargo stack-size --function cargo_stack_size::main`  
+**Note**: Functions may get inlined and thus won't show up here.
+Try using `[#inline(never)]` for function you wish to inspect.
+
+Show top 20 functions by stack size and filter anonymous closures:  
+`cargo stack-size --filter-closures`
+
+## Example Output
+```
+$ cargo stack-size --filter-closures --crate cargo_stack_size --emit-stack-sizes
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
+Inspecting stack size of target/debug/cargo-stack-size
+
+Size    Name
+1352    cargo_stack_size::bin_path_from_cargo
+1144    cargo_stack_size::main
+824     cargo_stack_size::sorted_functions
+536     cargo_stack_size::spawn_cargo
+```
+
+## Motivation
+Being able to inspect stack size quickly and easily of a function or crate is a handy way to gain insight
+into total stack footprint.
+
+Currently, a fantastic tool exists called [`cargo-call-stack`](https://github.com/japaric/cargo-call-stack)
+by [@japaric](https://github.com/japaric) which is great if you need to analyze the upper bound of stack
+depth and visualize the call graph.
+
+Unfortunately however, this tool does not currently work without some modifications.
+A [fork](https://github.com/Dirbaio/cargo-call-stack) by [@Dirbaio](https://github.com/Dirbaio)
+exists which does seem to work, and can be used to also provide a printed list of top functions by
+stack size, but it's not as simple to use and lacks some features for organizing by crate and function
+name.
+
+This tool makes use of the awesome [stack-sizes](https://crates.io/crates/stack-sizes) library also written
+by [@japaric](https://github.com/japaric). At one point this library also provided a binary version
+with similar functionality as this tool but has been abandoned in favor of `cargo-call-stack`.
+
+However, the value this tool provides over `cargo-call-stack` is ease of use and ability to inspect
+individual functions and crates when you don't need full call stack analysis.
+
+## Acknowledgements
+- Inspired by [@japaric](https://github.com/japaric)'s work on [`cargo-call-stack`](https://github.com/japaric/cargo-call-stack) and makes use of his [stack-sizes](https://crates.io/crates/stack-sizes) crate.

--- a/crates/cargo-stack-size/src/main.rs
+++ b/crates/cargo-stack-size/src/main.rs
@@ -1,0 +1,214 @@
+//! cargo-stack-size
+//!
+//! A tool for inspecting stack size of a binary by function and crate
+use cargo_metadata::{Message, camino::Utf8PathBuf};
+use clap::{ArgAction, Parser};
+use rustc_demangle::demangle;
+use stack_sizes::analyze_executable;
+use std::process::{Child, Command, Stdio};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "cargo stack-size",
+    version,
+    about = "Shows stack size of binary by function and crate.\n\n\
+    \
+    `-Zemit-stack-sizes` MUST be set for stack size information to be emitted by the linker.\n\
+    Additionally, depending on target, additional steps may need to be taken to ensure \
+    that the stack size section is kept.\n\n\
+    \
+    For ease of use, this tool can be instructed to emit stack sizes with the `--emit-stack-sizes` flag.\n\
+    Be warned however that this will override any RUSTFLAGS in .cargo/config.toml\n\n\
+    \
+    This ALWAYS builds with nightly as it is required for `-Zemit-stack-sizes`.\n\
+    Which means stack sizes may differ slightly from a stable build."
+)]
+struct Args {
+    #[arg(
+        short,
+        long,
+        help = "Number of lines to show, 0 to show all",
+        default_value_t = 20
+    )]
+    num: usize,
+
+    #[arg(long, help = "Space separated list of features to activate")]
+    features: Option<String>,
+
+    #[arg(
+        long = "crate",
+        help = "Show only functions belonging to specified crate"
+    )]
+    crate_name: Option<String>,
+
+    #[arg(long = "function", help = "Show only functions with specified name")]
+    function_name: Option<String>,
+
+    #[arg(
+        long,
+        allow_hyphen_values = true,
+        help = "Set RUSTFLAGS (be warned this will override any previous flags)"
+    )]
+    rustflags: Option<String>,
+
+    #[arg(long, action = ArgAction::SetTrue, help = "Shorthand for `--rustflags \"-Zemit-stack-sizes\"`")]
+    emit_stack_sizes: bool,
+
+    #[arg(long, action = ArgAction::SetTrue, help = "Filter anonymous closures")]
+    filter_closures: bool,
+
+    #[arg(long, action = ArgAction::SetTrue, help = "Build in release mode")]
+    release: bool,
+}
+
+struct Function {
+    name: String,
+    stack_sz: u64,
+}
+
+fn spawn_cargo(
+    release_mode: bool,
+    features: Option<String>,
+    rustflags: Option<String>,
+    emit_stack_sizes: bool,
+) -> std::io::Result<Child> {
+    let mut cargo = Command::new("cargo");
+
+    // Always build nightly since it's required for -Zemit-stack-sizes
+    cargo.args(["+nightly", "build"]);
+
+    if release_mode {
+        cargo.arg("--release");
+    }
+
+    if let Some(features) = features {
+        cargo.args(["--features", &features]);
+    }
+
+    // Only way to include -Zemit-stack-sizes here is to overwrite env::RUSTFLAGS
+    // But don't want to overwrite flags set by user (such as in .cargo/config.toml)
+    // Unfortunately don't see a way to append it
+    // If we retrieve the current env and append, that still misses rustflags from config.toml
+    // So let user decide if they want to override
+    if emit_stack_sizes && let Some(rustflags) = rustflags {
+        cargo.env("RUSTFLAGS", rustflags + " -Zemit-stack-sizes");
+    } else if emit_stack_sizes {
+        cargo.env("RUSTFLAGS", "-Zemit-stack-sizes");
+    } else if let Some(rustflags) = rustflags {
+        cargo.env("RUSTFLAGS", rustflags);
+    }
+
+    // First, build normally so user can see output if failed
+    // If it did fail, just exit early here
+    let status = cargo.status()?;
+    if !status.success() {
+        std::process::exit(1);
+    }
+
+    // Then build with output to json for message parsing
+    // This won't trigger a full rebuild since nothing has changed
+    cargo.arg("--message-format=json");
+    cargo.stdout(Stdio::piped()).spawn()
+}
+
+fn bin_path_from_cargo(mut cargo: Child) -> Option<Utf8PathBuf> {
+    let reader = std::io::BufReader::new(cargo.stdout.take()?);
+
+    // Just get the binary executable produced by cargo build
+    for message in Message::parse_stream(reader) {
+        if let Ok(Message::CompilerArtifact(artifact)) = message
+            && let Some(bin) = artifact.executable
+        {
+            cargo.wait().ok()?;
+            return Some(bin);
+        }
+    }
+
+    None
+}
+
+fn sorted_functions(
+    bin: &[u8],
+    crate_name: Option<String>,
+    function_name: Option<String>,
+    filter_closures: bool,
+) -> Option<Vec<Function>> {
+    let functions = analyze_executable(bin).ok()?;
+
+    // No stack size info found in ELF
+    if functions.defined.values().all(|f| f.stack().is_none()) {
+        return None;
+    }
+
+    let mut functions: Vec<Function> = functions
+        .defined
+        .iter()
+        .filter_map(|(_addr, f)| {
+            // {:#} removes the hash from the demangled name
+            let name = format!("{:#}", demangle(f.names().first()?));
+            let stack_sz = f.stack()?;
+
+            if filter_closures && name.ends_with("{{closure}}") {
+                return None;
+            }
+
+            // This doesn't *truly* check if a function belongs to a crate like `cargo bloat``
+            // Only checks if demgangled name begins with crate name which is good enough but not perfect
+            // May revisit with some tips from `cargo bloat`` if necessary
+            let keep = match (&crate_name, &function_name) {
+                (Some(crate_name), Some(function_name)) => {
+                    name.starts_with(crate_name) && name.contains(function_name)
+                }
+                (Some(crate_name), None) => name.starts_with(crate_name),
+                (None, Some(function_name)) => name.contains(function_name),
+                (None, None) => true,
+            };
+
+            if keep {
+                Some(Function { name, stack_sz })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    functions.sort_by_key(|f| std::cmp::Reverse(f.stack_sz));
+    Some(functions)
+}
+
+fn main() {
+    // Needed otherwise Clap will think "stack-size" is an argument when called as `cargo stack-size`
+    let mut args = std::env::args().collect::<Vec<_>>();
+    if args.len() > 1 && args[1] == "stack-size" {
+        args.remove(1);
+    }
+    let args = Args::parse_from(args);
+
+    let cargo = spawn_cargo(
+        args.release,
+        args.features,
+        args.rustflags,
+        args.emit_stack_sizes,
+    )
+    .expect("Failed to build binary");
+    let bin = bin_path_from_cargo(cargo).expect("Failed to locate binary");
+    println!("Inspecting stack size of {}\n", bin.as_str());
+
+    let bin = std::fs::read(bin).expect("Failed to read binary");
+    let functions = sorted_functions(
+        &bin,
+        args.crate_name,
+        args.function_name,
+        args.filter_closures,
+    )
+    .expect(
+        "No stack usage info found, \
+        ensure -Zemit-stack-sizes is set in RUSTFLAGS and stack size section is kept by linker",
+    );
+
+    println!("Size\tName");
+    let n = if args.num == 0 { usize::MAX } else { args.num };
+    for f in functions.iter().take(n) {
+        println!("{}\t{:#}", f.stack_sz, &f.name);
+    }
+}


### PR DESCRIPTION
Adds a tool called `cargo stack-size` which can used installed via `cargo install` for easily inspecting stack sizes of a binary by function or crate. Please see the `README` for more information.

If you would like to test it before merged, it can be installed via:
`cargo install --git https://github.com/kurtjd/odp-utilities --branch cargo-stack-size cargo-stack-size`

and then used as described in the `README`.

The clippy lint levels have been switched to `deny` as unfortunately `forbid` is too restrictive and doesn't even allow dependencies to override the lint level, which `clap` does.

**Edit**: Appears to be failing some CI checks for requiring `rustc 1.86` which is greater than MSRV, and for not passing `cargo deny`. However as this is a binary crate and not a library, I feel these don't apply. May move this to a different repo.